### PR TITLE
Use bitwise negation instead of logical not

### DIFF
--- a/EEPROMEx/EEPROMex.cpp
+++ b/EEPROMEx/EEPROMex.cpp
@@ -194,7 +194,7 @@ bool EEPROMClassEx::updateBit(int address, uint8_t bit, bool value)
 	  if (value) {	    
 		byteValOutput |= (1 << bit);  //Set bit to 1
 	  } else {		
-	    byteValOutput &= !(1 << bit); //Set bit to 0
+	    byteValOutput &= ~(1 << bit); //Set bit to 0
 	  }
 	  // Store if different from input
 	  if (byteValOutput!=byteValInput) {


### PR DESCRIPTION
I ran into a problem using this library when trying to set a single bit to 0. I had separated the byte into two bit-fields (0-2) and (3-7). Both fields had a single bit set as 1 (ie. bits 1 and 4 were set as 1). When writing a 1, it worked as expected, but writing a 0 would set all bits to 0. Looking through the code...

```
  byteValOutput &= !(1 << bit); //Set bit to 0
```

The right hand side of the equation evaluates to 00000000 every time due to the use of the logical not (!)
Using the bit-wise not (~) produces the correct result.

```
  byteValOutput &= ~(1 << bit); //Set bit to 0
```
