### PR TITLE
Update getAdress to getAddress, fixes compile errors in 2 examples

### DIFF
--- a/CmdMessenger/CmdMessenger.cpp
+++ b/CmdMessenger/CmdMessenger.cpp
@@ -38,7 +38,7 @@ extern "C" {
 }
 #include <stdio.h>
 #include <CmdMessenger.h>
-#include <Streaming.h>
+//#include <Streaming.h>
 
 #define _CMDMESSENGER_VERSION 3_0 // software version of this library
 

--- a/EEPROMEx/EEPROMBackupVar.h
+++ b/EEPROMEx/EEPROMBackupVar.h
@@ -38,14 +38,14 @@ template<typename T> class EEPROMBackupVar
 	  EEPROMBackupVar(T init, int range, compareFunction compareFunc,unsigned long time=0) {
 		adressRange = range;
 		timeBetweenSaves = time*1000; // from sec to milisec
-		baseAddress = EEPROM.getAdress(sizeof(T)*adressRange);	
+		baseAddress = EEPROM.getAddress(sizeof(T)*adressRange);	
 		function = compareFunc;
 		position = -1;		
 		var = init;		
 	  }
 	  	 	
 	  void initialize(T init){	    
-		baseAddress = EEPROM.getAdress(sizeof(T)*adressRange);
+		baseAddress = EEPROM.getAddress(sizeof(T)*adressRange);
 		retreive(init);	
 	  }				
 			  

--- a/EEPROMEx/EEPROMVar.h
+++ b/EEPROMEx/EEPROMVar.h
@@ -26,7 +26,7 @@ template<typename T> class EEPROMVar
 {
 	public:
 	  EEPROMVar(T init) {
-		address = EEPROM.getAdress(sizeof(T));	
+		address = EEPROM.getAddress(sizeof(T));
 		var = init;
 	  }
 	  operator T () { 
@@ -70,7 +70,7 @@ template<typename T> class EEPROMVar
 	    EEPROM.updateBlock<T>(address, var);
 	  }
 	  
-	  int getAdress(){	   	   
+	  int getAddress() {
 	    return address;
 	  }
 	  

--- a/EEPROMEx/Examples/EEPROMVar/EEPROMVar.pde
+++ b/EEPROMEx/Examples/EEPROMVar/EEPROMVar.pde
@@ -7,7 +7,7 @@
  */
 
 #include <EEPROMex.h>
-#include <EEPROMvar.h>
+#include <EEPROMVar.h>
 
 // start reading from the first byte (address 120) of the EEPROM
 
@@ -31,7 +31,7 @@ void readAndWriteVar(EEPROMVar<float> &floatVar) {
     floatVar.restore();  // restore EEPROMVar to EEPROM
     
     Serial.print("adress: ");
-    Serial.println(floatVar.getAdress());
+    Serial.println(floatVar.getAddress());
     Serial.print("input: ");
     Serial.println(input);
     Serial.print("output: ");

--- a/EEPROMEx/keywords.txt
+++ b/EEPROMEx/keywords.txt
@@ -9,7 +9,7 @@
 isReady			KEYWORD2
 setMemPool		KEYWORD2
 setMaxAllowedWrites	KEYWORD2
-getAdress		KEYWORD2
+getAddress		KEYWORD2
 
 read			KEYWORD2
 readByte		KEYWORD2


### PR DESCRIPTION
Here's another minor fix.  Sorry, this pull request also touches CmdMessenger.cpp which you've already modified, so this probably can't merge automatically.  I didn't realize that until just now, after pushing it up to github.  Forgot this is 1 repository for multiple libraries.

Anyway, the fix is simple, just replace every "getAdress" with "getAddress".

Discussion here....

http://forum.pjrc.com/threads/24589-Another-library-fails-to-compile%E2%80%A6-any-ideas-why?p=38033&viewfull=1#post38033