### PR TITLE
Fixes exceeding write limit warning during “readBlock” operations

### DIFF
--- a/EEPROMEx/EEPROMex.h
+++ b/EEPROMEx/EEPROMex.h
@@ -29,8 +29,8 @@
 #include <avr/eeprom.h>
 
 // Boards with ATmega328, Duemilanove, Uno, UnoSMD, Lilypad - 1024 bytes (1 kilobyte)
-// Boards with ATmega1280 or 2560, Arduino Mega series – 4096 bytes (4 kilobytes)
-// Boards with ATmega168, Lilypad, old Nano, Diecimila  – 512 bytes (1/2 kilobyte)
+// Boards with ATmega1280 or 2560, Arduino Mega series â€“ 4096 bytes (4 kilobytes)
+// Boards with ATmega168, Lilypad, old Nano, Diecimila  â€“ 512 bytes (1/2 kilobyte)
 
 #define EEPROMSizeATmega168   512     
 #define EEPROMSizeATmega328   1024     
@@ -94,7 +94,6 @@ class EEPROMClassEx
 
 	template <class T> int readBlock(int address, const T value[], int items)
 	{
-		if (!isWriteOk(address+items*sizeof(T))) return 0;
 		unsigned int i;
 		for (i = 0; i < (unsigned int)items; i++)
 			readBlock<T>(address+(i*sizeof(T)),value[i]);


### PR DESCRIPTION
removed isWriteOk for read operation