### PR TITLE
Turning EEPROMex debugging off by default

### DIFF
--- a/EEPROMEx/EEPROMex.cpp
+++ b/EEPROMEx/EEPROMex.cpp
@@ -27,7 +27,10 @@
  ******************************************************************************/
 
  #define _EEPROMEX_VERSION 1 // software version of this library
- #define _EEPROMEX_DEBUG     // Enables logging of maximum of writes and out-of-memory
+
+// leave debugging off by default
+// #define _EEPROMEX_DEBUG     // Enables logging of maximum of writes and out-of-memory
+
 /******************************************************************************
  * Constructors
  ******************************************************************************/


### PR DESCRIPTION
Turning EEPROMex debugging off by default.  Prevents conflicts with other UART devices out-of-the-box.
